### PR TITLE
Use the correct favicon link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <link rel="shortcut icon" href="https://github.com/gekkowrld-org.png" type="image/x-icon">
+  <link rel="shortcut icon" href="https://github.com/codetrybe.png" type="image/x-icon">
   <title>Git and Github</title>
   <style>
     body{


### PR DESCRIPTION
The previous link was pointing to a wrong place for the favicon. This edit will point to the right resource